### PR TITLE
Bug fix: Timer start time is not properly set to the current time

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,3 @@ In this phase I have tested my fixed version with Google Chrome only, not Firefo
 
   - Remove a little outdated presonal times functionality? The code is still there but not used.
   - Make this work in Daily Challenge too.
-
-### Notes
-
-  - After aborting a game a page reload should be done eg. by pressing F5. Otherwise the rounds aren't right.
-

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,6 +1,6 @@
 {
   "name": "GeoGuessr timer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "This extension adds timers to GeoGuessr score bar",
   "manifest_version": 3,
   "permissions": [

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,6 +1,6 @@
 {
   "name": "GeoGuessr timer",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "This extension adds timers to GeoGuessr score bar",
   "manifest_version": 2,
   "permissions": [

--- a/src/play.js
+++ b/src/play.js
@@ -123,6 +123,7 @@ const resetGame = () => {
     isStreak = null;
     currentMap = null;
     currentRound = 0;
+    roundRunning = false;
     roundsTime[1] = { begin: null, end: null };
     roundsTime[2] = { begin: null, end: null };
     roundsTime[3] = { begin: null, end: null };
@@ -353,7 +354,7 @@ const stopRound = () => {
 
 const tick = () => {
   const now = new Date();
-  if (document.querySelector('main[class^="in-game_layout"]')) {
+  if (document.querySelector('div[class^="game_status__"]')) {
     if (isStreak == null) {
       detectStreak();
     }
@@ -418,10 +419,10 @@ const tick = () => {
 const init = () => {
   if (config.active) {
     const observer = new MutationObserver(() => {
-      const gameLayout = document.querySelector('main[class^="in-game_layout"]');
+      const gameStatus = document.querySelector('div[class^="game_status__"]');
       const resultLayout = document.querySelector('div[class^="result-layout_root"]');
 
-      if (gameLayout) {
+      if (gameStatus) {
         if (resultLayout) {
           if (roundRunning) stopRound();
         } else if (currentRound !== getCurrentRound() && !roundRunning) {


### PR DESCRIPTION
This fix changes to observe `'div[class^="game_status__"]'` instead of `'main[class^="in-game_layout"]'`. The reason is that the game status DOM is loaded later than the in-game layout, so depending on the timing of the tick, startRound may not be called at the appropriate time, which may cause a bug that results in an incorrect start time as shown in the following image.

In addition, I modified `resetGame` to work without problems even if a player leaves an unfinished game.

I've already confirmed that the build is success and it works fine in my Chrome environment.

@fabrice404 Hi. Please review the fixes, and consider releasing a new version. Thank you!

<img width="764" alt="2023-10-30_22 43 22" src="https://github.com/fabrice404/geoguessr-timer/assets/1787125/7ec682d5-02ce-4a6b-8392-83abaaabd76b">
